### PR TITLE
lint and test targets need generated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           go-version: '^1.18'
 
+      - name: Run Generate Code
+        run: |
+          go generate ./...
+
       - name: Run Go Linter
         uses: golangci/golangci-lint-action@v3
         with:
@@ -37,6 +41,10 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '^1.18'
+
+      - name: Run Generate Code
+        run: |
+          go generate ./...
 
       - name: Run go tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ docker: files generate
 generate:
 	go generate ./...
 
-lint:
+lint: generate
 	golangci-lint run
 
-test:
+test: generate
 	go test ./...
 
 .PHONY: files


### PR DESCRIPTION
Fix Makefile generate required code on `lint` and `test` targets